### PR TITLE
Use greatest hop_limit for the same packet ID when retransmitting

### DIFF
--- a/src/input/ExpressLRSFiveWay.cpp
+++ b/src/input/ExpressLRSFiveWay.cpp
@@ -188,7 +188,7 @@ void ExpressLRSFiveWay::determineAction(KeyType key, PressLength length)
 // Feed input to the canned messages module
 void ExpressLRSFiveWay::sendKey(input_broker_event key)
 {
-    InputEvent e;
+    InputEvent e = {};
     e.source = inputSourceName;
     e.inputEvent = key;
     notifyObservers(&e);

--- a/src/input/LinuxInput.cpp
+++ b/src/input/LinuxInput.cpp
@@ -73,7 +73,7 @@ int32_t LinuxInput::runOnce()
         int rd = read(events[i].data.fd, ev, sizeof(ev));
         assert(rd > ((signed int)sizeof(struct input_event)));
         for (int j = 0; j < rd / ((signed int)sizeof(struct input_event)); j++) {
-            InputEvent e;
+            InputEvent e = {};
             e.inputEvent = INPUT_BROKER_NONE;
             e.source = this->_originName;
             e.kbchar = 0;

--- a/src/input/RotaryEncoderInterruptBase.cpp
+++ b/src/input/RotaryEncoderInterruptBase.cpp
@@ -45,7 +45,7 @@ void RotaryEncoderInterruptBase::init(
 
 int32_t RotaryEncoderInterruptBase::runOnce()
 {
-    InputEvent e;
+    InputEvent e = {};
     e.inputEvent = INPUT_BROKER_NONE;
     e.source = this->_originName;
     unsigned long now = millis();

--- a/src/input/SeesawRotary.cpp
+++ b/src/input/SeesawRotary.cpp
@@ -49,7 +49,7 @@ bool SeesawRotary::init()
 
 int32_t SeesawRotary::runOnce()
 {
-    InputEvent e;
+    InputEvent e = {};
     e.inputEvent = INPUT_BROKER_NONE;
     bool currentlyPressed = !ss.digitalRead(SS_SWITCH);
 

--- a/src/input/SerialKeyboard.cpp
+++ b/src/input/SerialKeyboard.cpp
@@ -29,7 +29,7 @@ SerialKeyboard::SerialKeyboard(const char *name) : concurrency::OSThread(name)
 
 void SerialKeyboard::erase()
 {
-    InputEvent e;
+    InputEvent e = {};
     e.inputEvent = INPUT_BROKER_BACK;
     e.kbchar = 0x08;
     e.source = this->_originName;
@@ -80,7 +80,7 @@ int32_t SerialKeyboard::runOnce()
 
         if (keys < prevKeys) { // a new key has been pressed (and not released), doesn't works for multiple presses at once but
                                // shouldn't be a limitation
-            InputEvent e;
+            InputEvent e = {};
             e.inputEvent = INPUT_BROKER_NONE;
             e.source = this->_originName;
             // SELECT OR SEND OR CANCEL EVENT

--- a/src/input/TouchScreenImpl1.cpp
+++ b/src/input/TouchScreenImpl1.cpp
@@ -47,7 +47,7 @@ bool TouchScreenImpl1::getTouch(int16_t &x, int16_t &y)
  */
 void TouchScreenImpl1::onEvent(const TouchEvent &event)
 {
-    InputEvent e;
+    InputEvent e = {};
     e.source = event.source;
     e.kbchar = 0;
     e.touchX = event.x;

--- a/src/input/TrackballInterruptBase.cpp
+++ b/src/input/TrackballInterruptBase.cpp
@@ -51,7 +51,7 @@ void TrackballInterruptBase::init(uint8_t pinDown, uint8_t pinUp, uint8_t pinLef
 
 int32_t TrackballInterruptBase::runOnce()
 {
-    InputEvent e;
+    InputEvent e = {};
     e.inputEvent = INPUT_BROKER_NONE;
 
     // Handle long press detection for press button

--- a/src/input/UpDownInterruptBase.cpp
+++ b/src/input/UpDownInterruptBase.cpp
@@ -48,7 +48,7 @@ void UpDownInterruptBase::init(uint8_t pinDown, uint8_t pinUp, uint8_t pinPress,
 
 int32_t UpDownInterruptBase::runOnce()
 {
-    InputEvent e;
+    InputEvent e = {};
     e.inputEvent = INPUT_BROKER_NONE;
     unsigned long now = millis();
 

--- a/src/input/kbI2cBase.cpp
+++ b/src/input/kbI2cBase.cpp
@@ -90,7 +90,7 @@ int32_t KbI2cBase::runOnce()
         while (keyCount--) {
             const BBQ10Keyboard::KeyEvent key = Q10keyboard.keyEvent();
             if ((key.key != 0x00) && (key.state == BBQ10Keyboard::StateRelease)) {
-                InputEvent e;
+                InputEvent e = {};
                 e.inputEvent = INPUT_BROKER_NONE;
                 e.source = this->_originName;
                 switch (key.key) {
@@ -187,7 +187,7 @@ int32_t KbI2cBase::runOnce()
     }
     case 0x37: { // MPR121
         MPRkeyboard.trigger();
-        InputEvent e;
+        InputEvent e = {};
 
         while (MPRkeyboard.hasEvent()) {
             char nextEvent = MPRkeyboard.dequeueEvent();
@@ -250,7 +250,7 @@ int32_t KbI2cBase::runOnce()
     }
     case 0x84: { // Adafruit TCA8418
         TCAKeyboard.trigger();
-        InputEvent e;
+        InputEvent e = {};
         while (TCAKeyboard.hasEvent()) {
             char nextEvent = TCAKeyboard.dequeueEvent();
             e.inputEvent = INPUT_BROKER_ANYKEY;
@@ -350,7 +350,7 @@ int32_t KbI2cBase::runOnce()
         }
         if (PrintDataBuf != 0) {
             LOG_DEBUG("RAK14004 key 0x%x pressed", PrintDataBuf);
-            InputEvent e;
+            InputEvent e = {};
             e.inputEvent = INPUT_BROKER_MATRIXKEY;
             e.source = this->_originName;
             e.kbchar = PrintDataBuf;
@@ -365,7 +365,7 @@ int32_t KbI2cBase::runOnce()
 
         if (i2cBus->available()) {
             char c = i2cBus->read();
-            InputEvent e;
+            InputEvent e = {};
             e.inputEvent = INPUT_BROKER_NONE;
             e.source = this->_originName;
             switch (c) {

--- a/src/input/kbMatrixBase.cpp
+++ b/src/input/kbMatrixBase.cpp
@@ -72,7 +72,7 @@ int32_t KbMatrixBase::runOnce()
             if (key != 0) {
                 LOG_DEBUG("Key 0x%x pressed", key);
                 // reset shift now that we have a keypress
-                InputEvent e;
+                InputEvent e = {};
                 e.inputEvent = INPUT_BROKER_NONE;
                 e.source = this->_originName;
                 switch (key) {

--- a/src/mesh/FloodingRouter.cpp
+++ b/src/mesh/FloodingRouter.cpp
@@ -30,8 +30,10 @@ bool FloodingRouter::shouldFilterReceived(const meshtastic_MeshPacket *p)
         // wasSeenRecently() reports false in upgrade cases so we handle replacement before the duplicate short-circuit
         // If we overhear a duplicate copy of the packet with more hops left than the one we are waiting to
         // rebroadcast, then remove the packet currently sitting in the TX queue and use this one instead.
-        if (iface->removePendingTXPacket(getFrom(p), p->id, p->hop_limit - 1)) {
-            LOG_DEBUG("Processing upgraded packet 0x%08x for rebroadcast with better hop limit (%d)", p->id, p->hop_limit - 1);
+        uint8_t dropThreshold = p->hop_limit; // remove queued packets that have fewer hops remaining
+        if (iface->removePendingTXPacket(getFrom(p), p->id, dropThreshold)) {
+            LOG_DEBUG("Processing upgraded packet 0x%08x for rebroadcast with hop limit %d (dropping queued < %d)", p->id,
+                      p->hop_limit, dropThreshold);
             return false; // Reprocess for routing only, skip app delivery
         }
     }

--- a/src/mesh/FloodingRouter.cpp
+++ b/src/mesh/FloodingRouter.cpp
@@ -28,7 +28,8 @@ bool FloodingRouter::shouldFilterReceived(const meshtastic_MeshPacket *p)
             // If we overhear a duplicate copy of the packet with more hops left than the one we are waiting to
             // rebroadcast, then remove the packet currently sitting in the TX queue and use this one instead.
             if (iface->removePendingTXPacket(getFrom(p), p->id, p->hop_limit - 1)) {
-                LOG_DEBUG("Processing upgraded packet %u for rebroadcast with better hop limit (%d)", p->id, p->hop_limit - 1);
+                LOG_DEBUG("Processing upgraded packet 0x%08x for rebroadcast with better hop limit (%d)", p->id,
+                          p->hop_limit - 1);
                 return false; // Reprocess for routing only, skip app delivery
             }
         }

--- a/src/mesh/FloodingRouter.cpp
+++ b/src/mesh/FloodingRouter.cpp
@@ -1,7 +1,7 @@
 #include "FloodingRouter.h"
-#include "meshUtils.h"
 #include "configuration.h"
 #include "mesh-pb-constants.h"
+#include "meshUtils.h"
 
 FloodingRouter::FloodingRouter() {}
 
@@ -28,14 +28,13 @@ bool FloodingRouter::shouldFilterReceived(const meshtastic_MeshPacket *p)
             // If we overhear a duplicate copy of the packet with more hops left than the one we are waiting to
             // rebroadcast, then remove the packet currently sitting in the TX queue and use this one instead.
             if (iface->removePendingTXPacket(getFrom(p), p->id, p->hop_limit - 1)) {
-                LOG_DEBUG("Processing upgraded packet %d for rebroadcast with better hop limit (%d)", p->id, p->hop_limit - 1);
+                LOG_DEBUG("Processing upgraded packet %u for rebroadcast with better hop limit (%d)", p->id, p->hop_limit - 1);
                 return false; // Reprocess for routing only, skip app delivery
             }
         }
 
         printPacket("Ignore dupe incoming msg", p);
         rxDupe++;
-
 
         // Handle ROUTER_LATE specific logic. Do not send to the regular queue.
 

--- a/src/mesh/FloodingRouter.cpp
+++ b/src/mesh/FloodingRouter.cpp
@@ -1,6 +1,5 @@
 #include "FloodingRouter.h"
 #include "meshUtils.h"
-
 #include "configuration.h"
 #include "mesh-pb-constants.h"
 
@@ -37,7 +36,9 @@ bool FloodingRouter::shouldFilterReceived(const meshtastic_MeshPacket *p)
         printPacket("Ignore dupe incoming msg", p);
         rxDupe++;
 
+
         // Handle ROUTER_LATE specific logic. Do not send to the regular queue.
+
         if (config.device.role == meshtastic_Config_DeviceConfig_Role_ROUTER_LATE && iface) {
             iface->clampToLateRebroadcastWindow(getFrom(p), p->id);
         }

--- a/src/mesh/NextHopRouter.cpp
+++ b/src/mesh/NextHopRouter.cpp
@@ -39,7 +39,7 @@ bool NextHopRouter::shouldFilterReceived(const meshtastic_MeshPacket *p)
         // Handle hop_limit upgrade scenario for routers
         if (wasUpgraded && IS_ROUTER_ROLE() && iface && p->hop_limit > 0) {
             if (iface->removePendingTXPacket(getFrom(p), p->id, p->hop_limit - 1)) {
-                LOG_DEBUG("Processing upgraded packet %d for relay with better hop limit (%d)", p->id, p->hop_limit - 1);
+                LOG_DEBUG("Processing upgraded packet %u for relay with better hop limit (%d)", p->id, p->hop_limit - 1);
                 return false; // Reprocess for routing only, skip app delivery
             }
         }

--- a/src/mesh/NextHopRouter.cpp
+++ b/src/mesh/NextHopRouter.cpp
@@ -39,7 +39,7 @@ bool NextHopRouter::shouldFilterReceived(const meshtastic_MeshPacket *p)
         // Handle hop_limit upgrade scenario for routers
         if (wasUpgraded && IS_ROUTER_ROLE() && iface && p->hop_limit > 0) {
             if (iface->removePendingTXPacket(getFrom(p), p->id, p->hop_limit - 1)) {
-                LOG_DEBUG("Processing upgraded packet %u for relay with better hop limit (%d)", p->id, p->hop_limit - 1);
+                LOG_DEBUG("Processing upgraded packet 0x%08x for relay with better hop limit (%d)", p->id, p->hop_limit - 1);
                 return false; // Reprocess for routing only, skip app delivery
             }
         }

--- a/src/mesh/NextHopRouter.cpp
+++ b/src/mesh/NextHopRouter.cpp
@@ -35,15 +35,19 @@ bool NextHopRouter::shouldFilterReceived(const meshtastic_MeshPacket *p)
     bool wasFallback = false;
     bool weWereNextHop = false;
     bool wasUpgraded = false;
-    if (wasSeenRecently(p, true, &wasFallback, &weWereNextHop, &wasUpgraded)) { // Note: this will also add a recent packet record
-        // Handle hop_limit upgrade scenario for routers
-        if (wasUpgraded && IS_ROUTER_ROLE() && iface && p->hop_limit > 0) {
-            if (iface->removePendingTXPacket(getFrom(p), p->id, p->hop_limit - 1)) {
-                LOG_DEBUG("Processing upgraded packet 0x%08x for relay with better hop limit (%d)", p->id, p->hop_limit - 1);
-                return false; // Reprocess for routing only, skip app delivery
-            }
-        }
+    bool seenRecently = wasSeenRecently(p, true, &wasFallback, &weWereNextHop,
+                                        &wasUpgraded); // Updates history; returns false when an upgrade is detected
 
+    // Handle hop_limit upgrade scenario for routers
+    if (wasUpgraded && IS_ROUTER_ROLE() && iface && p->hop_limit > 0) {
+        // Upgrade detection bypasses the duplicate short-circuit so we replace the queued packet before exiting
+        if (iface->removePendingTXPacket(getFrom(p), p->id, p->hop_limit - 1)) {
+            LOG_DEBUG("Processing upgraded packet 0x%08x for relay with better hop limit (%d)", p->id, p->hop_limit - 1);
+            return false; // Reprocess for routing only, skip app delivery
+        }
+    }
+
+    if (seenRecently) {
         printPacket("Ignore dupe incoming msg", p);
 
         if (p->transport_mechanism == meshtastic_MeshPacket_TransportMechanism_TRANSPORT_LORA) {

--- a/src/mesh/PacketHistory.cpp
+++ b/src/mesh/PacketHistory.cpp
@@ -84,8 +84,9 @@ bool PacketHistory::wasSeenRecently(const meshtastic_MeshPacket *p, bool withUpd
     bool seenRecently = (found != NULL);        // If found -> the packet was seen recently
 
     // Check for hop_limit upgrade scenario
-    if (seenRecently && wasUpgraded && found->hop_limit == 0 && p->hop_limit > 0) {
-        LOG_DEBUG("Packet History - Hop limit upgrade: packet %u from hop_limit=0 to hop_limit=%d", p->id, p->hop_limit);
+    if (seenRecently && wasUpgraded && found->hop_limit < p->hop_limit) {
+        LOG_DEBUG("Packet History - Hop limit upgrade: packet %u from hop_limit=%d to hop_limit=%d", p->id, found->hop_limit,
+                  p->hop_limit);
         *wasUpgraded = true;
         seenRecently = false; // Allow router processing but prevent duplicate app delivery
     } else if (wasUpgraded) {

--- a/src/mesh/PacketHistory.cpp
+++ b/src/mesh/PacketHistory.cpp
@@ -138,6 +138,11 @@ bool PacketHistory::wasSeenRecently(const meshtastic_MeshPacket *p, bool withUpd
                       millis() - found->rxTimeMsec);
 #endif
 
+            // Preserve the highest hop_limit we've ever seen for this packet so upgrades aren't lost when a later copy has
+            // fewer hops remaining.
+            if (found->hop_limit > r.hop_limit)
+                r.hop_limit = found->hop_limit;
+
             // Add the existing relayed_by to the new record
             for (uint8_t i = 0; i < (NUM_RELAYERS - 1); i++) {
                 if (found->relayed_by[i] != 0)

--- a/src/mesh/PacketHistory.cpp
+++ b/src/mesh/PacketHistory.cpp
@@ -85,7 +85,7 @@ bool PacketHistory::wasSeenRecently(const meshtastic_MeshPacket *p, bool withUpd
 
     // Check for hop_limit upgrade scenario
     if (seenRecently && wasUpgraded && found->hop_limit == 0 && p->hop_limit > 0) {
-        LOG_DEBUG("Packet History - Hop limit upgrade: packet %d from hop_limit=0 to hop_limit=%d", p->id, p->hop_limit);
+        LOG_DEBUG("Packet History - Hop limit upgrade: packet %u from hop_limit=0 to hop_limit=%d", p->id, p->hop_limit);
         *wasUpgraded = true;
         seenRecently = false; // Allow router processing but prevent duplicate app delivery
     } else if (wasUpgraded) {

--- a/src/mesh/PacketHistory.cpp
+++ b/src/mesh/PacketHistory.cpp
@@ -85,7 +85,7 @@ bool PacketHistory::wasSeenRecently(const meshtastic_MeshPacket *p, bool withUpd
 
     // Check for hop_limit upgrade scenario
     if (seenRecently && wasUpgraded && found->hop_limit < p->hop_limit) {
-        LOG_DEBUG("Packet History - Hop limit upgrade: packet %u from hop_limit=%d to hop_limit=%d", p->id, found->hop_limit,
+        LOG_DEBUG("Packet History - Hop limit upgrade: packet 0x%08x from hop_limit=%d to hop_limit=%d", p->id, found->hop_limit,
                   p->hop_limit);
         *wasUpgraded = true;
         seenRecently = false; // Allow router processing but prevent duplicate app delivery

--- a/src/mesh/PacketHistory.h
+++ b/src/mesh/PacketHistory.h
@@ -16,7 +16,7 @@ class PacketHistory
         PacketId id;
         uint32_t rxTimeMsec;              // Unix time in msecs - the time we received it,  0 means empty
         uint8_t next_hop;                 // The next hop asked for this packet
-        uint8_t hop_limit;                // The hop limit when we received this packet
+        uint8_t hop_limit;                // Highest hop limit observed for this packet
         uint8_t relayed_by[NUM_RELAYERS]; // Array of nodes that relayed this packet
     };                                    // 4B + 4B + 4B + 1B + 1B + 3B = 17B (will be padded to 20B)
 

--- a/src/mesh/RadioLibInterface.cpp
+++ b/src/mesh/RadioLibInterface.cpp
@@ -370,7 +370,7 @@ bool RadioLibInterface::removePendingTXPacket(NodeNum from, PacketId id, uint32_
 {
     meshtastic_MeshPacket *p = txQueue.remove(from, id, true, true, hop_limit_lt);
     if (p) {
-        LOG_DEBUG("Dropping pending-TX packet %u with hop limit %d", p->id, p->hop_limit);
+        LOG_DEBUG("Dropping pending-TX packet 0x%08x with hop limit %d", p->id, p->hop_limit);
         packetPool.release(p);
         return true;
     }

--- a/src/mesh/RadioLibInterface.cpp
+++ b/src/mesh/RadioLibInterface.cpp
@@ -370,13 +370,12 @@ bool RadioLibInterface::removePendingTXPacket(NodeNum from, PacketId id, uint32_
 {
     meshtastic_MeshPacket *p = txQueue.remove(from, id, true, true, hop_limit_lt);
     if (p) {
-        LOG_DEBUG("Dropping pending-TX packet %d with hop limit %d", p->id, p->hop_limit);
+        LOG_DEBUG("Dropping pending-TX packet %u with hop limit %d", p->id, p->hop_limit);
         packetPool.release(p);
         return true;
     }
     return false;
 }
-
 
 /**
  * Remove a packet that is eligible for replacement from the TX queue

--- a/src/mesh/RadioLibInterface.cpp
+++ b/src/mesh/RadioLibInterface.cpp
@@ -377,6 +377,7 @@ bool RadioLibInterface::removePendingTXPacket(NodeNum from, PacketId id, uint32_
     return false;
 }
 
+
 /**
  * Remove a packet that is eligible for replacement from the TX queue
  */

--- a/src/mesh/RadioLibInterface.h
+++ b/src/mesh/RadioLibInterface.h
@@ -223,4 +223,3 @@ class RadioLibInterface : public RadioInterface, protected concurrency::Notified
 
     bool removePendingTXPacket(NodeNum from, PacketId id, uint32_t hop_limit_lt) override;
 };
-

--- a/src/mesh/RadioLibInterface.h
+++ b/src/mesh/RadioLibInterface.h
@@ -220,5 +220,7 @@ class RadioLibInterface : public RadioInterface, protected concurrency::Notified
      * If there is a packet pending TX in the queue with a worse hop limit, remove it pending replacement with a better version
      * @return Whether a pending packet was removed
      */
+
     bool removePendingTXPacket(NodeNum from, PacketId id, uint32_t hop_limit_lt) override;
 };
+


### PR DESCRIPTION
## Summary
- Rework hop-limit upgrade handling so routers swap in better packets without losing duplicate suppression.
- Use packet history to save the best hop limit seen (This will increase memory 3 bytes/packet)
- Improve TX queue tooling/logging to make it obvious when and why entries are replaced

## Details
### Router hop-limit flow
- Refactored `FloodingRouter::shouldFilterReceived()` and `NextHopRouter::shouldFilterReceived()` to call `wasSeenRecently()` once, capture the new `wasUpgraded` flag, and run upgrade replacement before the duplicate early-return. This lets the routers reuse the upgraded frame while still filtering true dupes.
- Gate the upgrade path on `IS_ROUTER_ROLE()` and require `hop_limit > 0`, then call `removePendingTXPacket()` with the new packet’s hop limit so only worse queued copies are removed. Log messages now report the threshold being applied.

### Packet history tracking
- Extended `PacketHistory::wasSeenRecently()` with an optional `wasUpgraded` out-parameter and persisted the maximum hop limit observed for each packet. Seeing a higher hop count sets `wasUpgraded`, suppresses the duplicate fast path, and keeps the higher value even if later retransmissions arrive with fewer hops.
- Updated `PacketRecord` metadata and comments to reflect the new “highest hop limit”

### TX queue utilities and logging
- Added `MeshPacketQueue::getPacketFromQueue()` so queue lookups can reuse the same search logic, and simplified `find()` to delegate to it.
- Marked `RadioLibInterface::removePendingTXPacket()` as an override and switched the diagnostic to log packet IDs in hex, matching other debugging output.

## Testing
- Manual log inspection while passing upgraded hop-limit traffic using a production node set to ROUTER_LATE.

### Example logs

```
DEBUG | 15:55:41 190 [Router] Packet History - Hop limit upgrade: packet 0x6a2f0d5d from hop_limit=1 to hop_limit=2
DEBUG | 15:57:45 315 [Router] Packet History - Hop limit upgrade: packet 0x69051dd8 from hop_limit=0 to hop_limit=1
DEBUG | 15:57:48 318 [Router] Packet History - Hop limit upgrade: packet 0x8f299f10 from hop_limit=1 to hop_limit=2
DEBUG | 15:58:36 366 [Router] Packet History - Hop limit upgrade: packet 0x0424a99c from hop_limit=0 to hop_limit=2
```
```
DEBUG | 15:55:41 190 [Router] Dropping pending-TX packet 0x6a2f0d5d with hop limit 0
DEBUG | 15:57:48 318 [Router] Dropping pending-TX packet 0x8f299f10 with hop limit 0
DEBUG | 16:06:25 834 [Router] Dropping pending-TX packet 0x60a989c2 with hop limit 3
```

## 🤝 Attestations

- [X] I have tested that my proposed changes behave as described.
- [X] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [X] Other (please specify below)
Station G2